### PR TITLE
Added sign-in sign-out modal

### DIFF
--- a/src/app/@modal/(.)sign-in/page.tsx
+++ b/src/app/@modal/(.)sign-in/page.tsx
@@ -1,0 +1,30 @@
+import { LoginFormModal } from '@/components/auth/login/login-form-modal'
+
+import { FormFooter } from '@/components/auth/login/login-form-footer'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+
+export default function DialogSignIn() {
+  return (
+    <Dialog open={true} isRouterBack >
+      <DialogContent className="sm:max-w-[425px]" >
+        <DialogHeader className="space-y-1 text-center">
+          <DialogTitle className="text-2xl">Sign in to your account</DialogTitle>
+          <DialogDescription>Enter your credentials to sign in</DialogDescription>
+        </DialogHeader>
+        <LoginFormModal />
+        <DialogFooter>
+          <FormFooter />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/@modal/(.)sign-up/page.tsx
+++ b/src/app/@modal/(.)sign-up/page.tsx
@@ -1,0 +1,29 @@
+import { RegisterFormModal } from '@/components/auth/register/register-form-modal'
+
+import { FormFooter } from '@/components/auth/register/register-form-footer'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+
+export default function DialogDemo() {
+  return (
+    <Dialog open={true} isRouterBack >
+      <DialogContent className="sm:max-w-[425px]" >
+        <DialogHeader className="space-y-1 text-center w-full flex justify-center">
+          <DialogTitle className="text-2xl ">Create an account</DialogTitle>
+          <DialogDescription>Enter your details to register</DialogDescription>
+        </DialogHeader>
+        <RegisterFormModal />
+        <DialogFooter>
+          <FormFooter />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/@modal/default.tsx
+++ b/src/app/@modal/default.tsx
@@ -1,0 +1,4 @@
+
+const Default=()=> null
+
+export default Default

--- a/src/app/@modal/page.tsx
+++ b/src/app/@modal/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+
+
+const Default=()=> null
+
+export default Default

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,28 +1,32 @@
-import { Metadata } from 'next';
-import { Inter as FontSans } from 'next/font/google';
+import { Metadata } from 'next'
+import { Inter as FontSans } from 'next/font/google'
 
-import { Providers } from '@/components/providers/providers';
-import { PageFooter } from '@/components/static/page-footer';
-import { PageHeader } from '@/components/static/page-header';
-import { cn } from '@/lib/utils';
+import { Providers } from '@/components/providers/providers'
+import { PageFooter } from '@/components/static/page-footer'
+import { PageHeader } from '@/components/static/page-header'
+import { cn } from '@/lib/utils'
 
-import './globals.css';
+import './globals.css'
 
 const fontSans = FontSans({
   subsets: ['latin'],
   variable: '--font-sans',
-});
+})
 
 export const metadata: Metadata = {
   title: 'hfun.info',
   description: 'Habbo Origins: ES | Fansite',
-};
+}
 
 export default async function RootLayout({
   children,
+  modal,
+
 }: Readonly<{
-  children: React.ReactNode;
+  children: React.ReactNode
+  modal: React.ReactNode
 }>) {
+
   return (
     <html lang="en" suppressHydrationWarning>
       <body
@@ -35,10 +39,11 @@ export default async function RootLayout({
       >
         <Providers>
           <PageHeader />
+          {modal}
           <main className="flex-grow">{children}</main>
           <PageFooter />
         </Providers>
       </body>
     </html>
-  );
+  )
 }

--- a/src/app/sign-in/page.tsx
+++ b/src/app/sign-in/page.tsx
@@ -1,9 +1,9 @@
-import { LoginForm } from '@/components/auth/login/login-form';
+import { LoginForm } from '@/components/auth/login/login-form'
 
 export default function SignInPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <LoginForm />
     </div>
-  );
+  )
 }

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,9 +1,9 @@
-import { RegisterForm } from '@/components/auth/register/register-form';
+import { RegisterForm } from '@/components/auth/register/register-form'
 
 export default function SignUpPage() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <RegisterForm />
     </div>
-  );
+  )
 }

--- a/src/components/auth/login/login-form-footer.tsx
+++ b/src/components/auth/login/login-form-footer.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import Link from 'next/link'
 
 export function FormFooter() {
   return (
@@ -11,10 +11,11 @@ export function FormFooter() {
         <Link
           href="/sign-up"
           className="font-medium text-primary hover:underline"
+          replace
         >
           Sign up
         </Link>
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/auth/login/login-form-modal.tsx
+++ b/src/components/auth/login/login-form-modal.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { useRouter } from 'next/navigation'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { toast } from 'sonner'
+import { useCountdown } from 'usehooks-ts'
+
+import { LoginFormFields } from '@/components/auth/login/login-form-fields'
+import { FormFooter } from '@/components/auth/login/login-form-footer'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Countdown } from '@/components/ui/countdown'
+import { Form } from '@/components/ui/form'
+import { type LoginSchema, loginSchema } from '@/schemas/auth'
+import { sendVerificationEmail } from '@/server/actions/auth/send-verification-email/send-verification-email'
+import { signIn } from '@/server/actions/auth/sign-in/sign-in'
+
+export function LoginFormModal() {
+  const form = useForm<LoginSchema>({
+    resolver: zodResolver(loginSchema),
+  })
+
+  const router = useRouter()
+  const [isEmailNotVerified, setIsEmailNotVerified] = useState(false)
+  const [email, setEmail] = useState('')
+
+  const [showCountdown, setShowCountdown] = useState(false)
+
+  const handleCountdownComplete = () => {
+    setShowCountdown(false)
+  }
+
+  const onSubmit = async (values: LoginSchema) => {
+    const response = await signIn(values)
+
+    if (!response.success && response.error) {
+      if (response.error === 'Email not verified') {
+        setIsEmailNotVerified(true)
+        setEmail(values.email)
+      }
+      toast.error(response.error)
+      return
+    }
+
+    toast.success('Logged in successfully')
+    router.push('/')
+  }
+
+  const handleSendVerificationEmail = async () => {
+    const response = await sendVerificationEmail(email)
+    if (response.success) {
+      toast.success('Verification email sent successfully')
+      setShowCountdown(true)
+    } else {
+      toast.error(response.error)
+    }
+  }
+
+  return (
+    <>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <LoginFormFields control={form.control} />
+          <Button type="submit" className="w-full">
+            Sign In
+          </Button>
+        </form>
+      </Form>
+      {isEmailNotVerified && (
+        <div className="mt-4">
+          {showCountdown ? (
+            <Countdown
+              initialCount={60}
+              onResend={handleSendVerificationEmail}
+              resendButtonText="Resend Verification Email"
+              className="justify-between w-full"
+            />
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={handleSendVerificationEmail}
+              disabled={showCountdown}
+            >
+              Send Verification Email
+            </Button>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/auth/register/register-form-fields.tsx
+++ b/src/components/auth/register/register-form-fields.tsx
@@ -1,6 +1,6 @@
-import { Control } from 'react-hook-form';
+import { Control } from 'react-hook-form'
 
-import { Mail, User } from 'lucide-react';
+import { Mail, User } from 'lucide-react'
 
 import {
   FormControl,
@@ -9,13 +9,13 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-} from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { PasswordInput } from '@/components/ui/password-input';
-import { RegisterSchema } from '@/schemas/auth';
+} from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { PasswordInput } from '@/components/ui/password-input'
+import { RegisterSchema } from '@/schemas/auth'
 
 interface RegisterFormFieldsProps {
-  control: Control<RegisterSchema>;
+  control: Control<RegisterSchema>
 }
 
 export function RegisterFormFields({ control }: RegisterFormFieldsProps) {
@@ -81,5 +81,5 @@ export function RegisterFormFields({ control }: RegisterFormFieldsProps) {
         description="Please re-enter your password to confirm."
       />
     </>
-  );
+  )
 }

--- a/src/components/auth/register/register-form-footer.tsx
+++ b/src/components/auth/register/register-form-footer.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import Link from 'next/link'
 
 export function FormFooter() {
   return (
@@ -8,10 +8,11 @@ export function FormFooter() {
         <Link
           href="/sign-in"
           className="font-medium text-primary hover:underline"
+          replace
         >
           Sign in
         </Link>
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/auth/register/register-form-modal.tsx
+++ b/src/components/auth/register/register-form-modal.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { toast } from 'sonner'
+
+import { RegisterFormFields } from '@/components/auth/register/register-form-fields'
+import { FormFooter } from '@/components/auth/register/register-form-footer'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Countdown } from '@/components/ui/countdown'
+import { Form } from '@/components/ui/form'
+import { type RegisterSchema, registerSchema } from '@/schemas/auth'
+import { sendVerificationEmail } from '@/server/actions/auth/send-verification-email/send-verification-email'
+import { createAccount } from '@/server/actions/auth/sign-up/sign-up'
+
+export function RegisterFormModal() {
+  const form = useForm<RegisterSchema>({
+    resolver: zodResolver(registerSchema),
+  })
+
+  const [isEmailSent, setIsEmailSent] = useState(false)
+  const [email, setEmail] = useState('')
+  const [showCountdown, setShowCountdown] = useState(false)
+
+  const onSubmit = async (values: RegisterSchema) => {
+    const response = await createAccount(values)
+
+    if (!response.success && response.error) {
+      toast.error(response.error)
+      return
+    }
+
+    setIsEmailSent(true)
+    setEmail(values.email)
+    setShowCountdown(true)
+    toast.success(
+      'We have sent a verification email to your inbox. Please verify your email to continue.',
+    )
+  }
+
+  const handleSendVerificationEmail = async () => {
+    const response = await sendVerificationEmail(email)
+    if (response.success) {
+      toast.success('Verification email sent successfully')
+      setShowCountdown(true)
+    } else {
+      toast.error(response.error)
+    }
+  }
+
+  return (
+
+
+    <>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <RegisterFormFields control={form.control} />
+          <Button type="submit" className="w-full" disabled={isEmailSent}>
+            Register
+          </Button>
+        </form>
+      </Form>
+      {isEmailSent && (
+        <div className="mt-4">
+          {showCountdown ? (
+            <Countdown
+              initialCount={60}
+              onResend={handleSendVerificationEmail}
+              resendButtonText="Resend Verification Email"
+              className="justify-between w-full"
+            />
+          ) : (
+            <Button
+              type="button"
+              variant="outline"
+              className="w-full"
+              onClick={handleSendVerificationEmail}
+              disabled={showCountdown}
+            >
+              Send Verification Email
+            </Button>
+          )}
+        </div>
+      )}
+    </>
+
+
+  )
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,19 +1,27 @@
-'use client';
+'use client'
 
-import * as React from 'react';
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { useRouter } from 'next/navigation'
+import { X } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
+interface DialogRouterProps extends DialogPrimitive.DialogProps {
+  isRouterBack?: boolean
+  interactOutside?: boolean
+}
 
-import { cn } from '@/lib/utils';
+const Dialog = ({ children, isRouterBack, ...props }: DialogRouterProps) => {
+  const router = useRouter()
 
-const Dialog = DialogPrimitive.Root;
+  return <DialogPrimitive.Root onOpenChange={() => isRouterBack && router.back()} {...props}>{children}</DialogPrimitive.Root>
+}
 
-const DialogTrigger = DialogPrimitive.Trigger;
+const DialogTrigger = DialogPrimitive.Trigger
 
-const DialogPortal = DialogPrimitive.Portal;
+const DialogPortal = DialogPrimitive.Portal
 
-const DialogClose = DialogPrimitive.Close;
+const DialogClose = DialogPrimitive.Close
 
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
@@ -27,8 +35,8 @@ const DialogOverlay = React.forwardRef<
     )}
     {...props}
   />
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -37,6 +45,7 @@ const DialogContent = React.forwardRef<
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
+      onInteractOutside={(e) => e.preventDefault()}
       ref={ref}
       className={cn(
         'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
@@ -51,18 +60,18 @@ const DialogContent = React.forwardRef<
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
-));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
 
 const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
-);
-DialogHeader.displayName = 'DialogHeader';
+)
+DialogHeader.displayName = 'DialogHeader'
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />
-);
-DialogFooter.displayName = 'DialogFooter';
+)
+DialogFooter.displayName = 'DialogFooter'
 
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
@@ -73,16 +82,16 @@ const DialogTitle = React.forwardRef<
     className={cn('text-lg font-semibold leading-none tracking-tight', className)}
     {...props}
   />
-));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
 
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
 
 export {
   Dialog,
@@ -95,4 +104,4 @@ export {
   DialogFooter,
   DialogTitle,
   DialogDescription,
-};
+}


### PR DESCRIPTION
-added parallel routing and router interception for modal forms

Changes needed:

- Moved login/register pages out of group for router interception
- create Forms without card for use dialog elements.
- added routerBack to dialog to return to previous page on close dialog
- change dialog to avoid close on clickOutside (todo add prop to make this behaviour optional)
- added replace to navigation Links between sign-in sign-out to avoid loops on router.back